### PR TITLE
fix nanorequest API definition string

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ const req = request(opts, (err, res, body) => {
 
 ### API
 
-#### `nanorequest(opts:object(key:string), cb(err:Error, res:[Response](https://nodejs.org/api/http.html#http_class_http_serverresponse), body:(mixed)):function):[Request](https://nodejs.org/api/http.html#http_class_http_clientrequest)`
+#### nanorequest(opts:object(key:string), cb(err:Error, res:[Response](https://nodejs.org/api/http.html#http_class_http_serverresponse), body:(mixed)):function):[Request](https://nodejs.org/api/http.html#http_class_http_clientrequest)
 The `opts` object matches the options used in [`http.request`](https://nodejs.org/api/http.html#http_http_request_options_callback), but accepts an optional `url` field.
 * `opts.url:string` - the URL you want to request. Will be parsed with [`url.parse`](https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost).
 


### PR DESCRIPTION
removed backticks, which makes the links render correctly

## before

<img width="908" alt="screen shot 2017-06-20 at 12 11 42 pm" src="https://user-images.githubusercontent.com/427322/27351333-ce51d588-55b1-11e7-80e8-75b62fe48bf4.png">

## after

<img width="808" alt="screen shot 2017-06-20 at 12 12 16 pm" src="https://user-images.githubusercontent.com/427322/27351327-c6d06a86-55b1-11e7-8ba8-ed79bad902b3.png">
