### PR TITLE
Can't use .length for multi-byte strings

### DIFF
--- a/nanorequest.js
+++ b/nanorequest.js
@@ -31,7 +31,7 @@ module.exports = function sendRequest (opts, cb) {
     if (!opts.headers) {
       opts.headers = {}
     }
-    opts.headers['content-length'] = reqBody.length
+    opts.headers['content-length'] = Buffer.byteLength(reqBody, 'utf8')
   }
 
   var lib = opts.protocol === 'https:' ? https : http
@@ -79,4 +79,3 @@ module.exports = function sendRequest (opts, cb) {
     cb(err, res, err.message)
   }
 }
-

--- a/test/nanorequest.spec.js
+++ b/test/nanorequest.spec.js
@@ -28,6 +28,9 @@ const httpServer = http.createServer((req, res) => {
   } else if (req.url === '/bad-json') {
     res.setHeader('content-type', 'application/json')
     res.end('{message": "aseddd}')
+  } else if (req.url === '/byte-me') {
+    res.setHeader('content-type', 'application/json')
+    res.end(`{"emojilength": ${req.headers['content-length']}}`)
   } else {
     res.statusCode = 404
     res.end('Not found')
@@ -165,6 +168,22 @@ test('bad json,', (t) => {
   req(opts, (err, res, body) => {
     t.ok(err, 'got error')
     t.ok(body.indexOf('Unexpected token m') > -1, 'bad parsing')
+    t.end()
+  })
+})
+
+test('byte length,', (t) => {
+  const opts = {
+    method: 'get',
+    url: 'http://localhost:8080/byte-me',
+    body: {emoji: '🐒'},
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+  req(opts, (err, res, body) => {
+    t.error(err, 'no error')
+    t.equal(body.emojilength, 16, '2 bytes')
     t.end()
   })
 })


### PR DESCRIPTION
The fun thing about javascript is that it lets you put multi-byte characters
in strings just fine, but it can't count them properly.

Use the Buffer object to properly count the number of bytes to account for
multi-byte strings

changes made:
---
- [x] Use Buffer.byteLength instead of String.prototype.length

version:
---
- patch