### PR TITLE
Remove fast-json-parse

### DIFF
--- a/nanorequest.js
+++ b/nanorequest.js
@@ -3,7 +3,6 @@ var https = require('https')
 var url = require('url')
 
 var stringify = require('fast-safe-stringify')
-var parse = require('fast-json-parse')
 var concat = require('concat-stream')
 
 function json (obj) {
@@ -67,11 +66,11 @@ module.exports = function sendRequest (opts, cb) {
       var err = null
 
       if (json(res)) {
-        var result = parse(buf.toString('utf8'))
-        if (result.err) {
-          return handleError(result.err, res)
+        try {
+          buf = JSON.parse(buf.toString('utf8'))
+        } catch (err) {
+          return handleError(err, res)
         }
-        buf = result.value
       }
 
       if (text(res)) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "concat-stream": "^1.6.2",
-    "fast-json-parse": "^1.0.3",
     "fast-safe-stringify": "^2.0.4"
   },
   "engines": {


### PR DESCRIPTION
v8 no longer de-optimizes try/catch blocks, so we don't need to relegate this
to a separate function since we require node 8